### PR TITLE
Add Linux 4.x in PLATFORMS

### DIFF
--- a/PLATFORMS
+++ b/PLATFORMS
@@ -18,6 +18,7 @@ HP-UX 11.23 (ia64)
 HP-UX 11.31 (ia64)
 Linux 2.6 (Ubuntu 10.04, SLES 9-11, Red Hat 6, CentOS 6)
 Linux 3.X (Ubuntu 12.04, 14.04)
+Linux 4.X (Fedora 22, 23)
 NetBSD 5.1
 NetBSD 6.1
 OpenBSD 4.9


### PR DESCRIPTION
I've verified this on Fedora Rawhide with kernel 4.x and all examples and library itself work fine.