### PR TITLE
Move LINKFLAGS to libs.private

### DIFF
--- a/libstatgrab.pc.in
+++ b/libstatgrab.pc.in
@@ -11,5 +11,6 @@ bin_perm=@BIN_PERM@
 Name: libstatgrab
 Description: Provides a useful interface to system statistics
 Version: @VERSION@
-Libs: -L${libdir} -lstatgrab @LINKFLAGS@
+Libs: -L${libdir} -lstatgrab
+Libs.private: @LINKFLAGS@
 Cflags: -I${includedir}


### PR DESCRIPTION
In my understanding, Libs field should only include -lstatgrab for other programs to link with, now if I enable logging support via log4cplus the generated file will become:

Libs: -L${libdir} -lstatgrab -llog4cplus

Which is incorrect I believe. Other programs shouldn't link with log4cplus directly, but now the result will be opposite. Thus moving LINKFLAGS to libs.private is fine.