### PR TITLE
Allow manual pages to be completely disabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1513,9 +1513,9 @@ AC_MSG_RESULT($ac_cv_enable_examples)
 
 # Check if user wants to make and install manpages
 # XXX split between make and install
-AC_ARG_ENABLE(man-build,
-[  --enable-man-build      enable building of manpages (default in maintainer-mode)
-  --disable-man-build     disable building of manpages (default in all other cases)],
+AC_ARG_ENABLE(man,
+[  --enable-man            enable building/installation of manpages (default in maintainer-mode)
+  --disable-man           disable building/installation of manpages (default in all other cases)],
 	[ENABLE_BUILD_MANPAGES="${enableval}"],
 	[
 		AS_IF(	[test "x$USE_MAINTAINER_MODE" = "xyes"],
@@ -1525,9 +1525,9 @@ AC_ARG_ENABLE(man-build,
 	]
 )
 
-AM_CONDITIONAL(BUILD_MANPAGES, false)
+AM_CONDITIONAL(MANPAGES, false)
 AS_IF(	[test "x${ENABLE_BUILD_MANPAGES}" = "xno"],
-	[AM_CONDITIONAL(BUILD_MANPAGES, false)],
+	[AM_CONDITIONAL(MANPAGES, false)],
 	[
 		dnl check if whether docbook is available
 		AC_MSG_CHECKING([for applicable docbook2man])
@@ -1548,7 +1548,7 @@ AS_IF(	[test "x${ENABLE_BUILD_MANPAGES}" = "xno"],
 			],
 			[test "x$ac_cv_path_docbook2man_prog" != "xnone"],
 			[
-				AM_CONDITIONAL(BUILD_MANPAGES, true)
+				AM_CONDITIONAL(MANPAGES, true)
 				DOCBOOK2MAN="$ac_cv_path_docbook2man_prog"
 				AC_SUBST(DOCBOOK2MAN)
 				AC_MSG_NOTICE([enabling build of manpages using $DOCBOOK2MAN])

--- a/docs/libstatgrab/Makefile.am
+++ b/docs/libstatgrab/Makefile.am
@@ -2,6 +2,7 @@
 # http://www.i-scream.org/libstatgrab/
 # $Id$
 
+if MANPAGES
 man_MANS =	$(statgrab_MANS) $(sg_cpu_MANS) $(sg_disk_MANS) $(sg_error_MANS) \
 		$(sg_fs_MANS) $(sg_host_MANS) $(sg_load_MANS) $(sg_mem_MANS) \
 		$(sg_netif_MANS) $(sg_netio_MANS) $(sg_page_MANS) $(sg_proc_MANS) \
@@ -81,7 +82,6 @@ sg_tools_MANS =	sg_update_string.3
 
 EXTRA_DIST = $(man_MANS)
 
-if BUILD_MANPAGES
 MAINTAINERCLEANFILES= $(man_MANS)
 
 .NOTPARALLEL :

--- a/docs/saidar/Makefile.am
+++ b/docs/saidar/Makefile.am
@@ -2,13 +2,13 @@
 # http://www.i-scream.org/libstatgrab/
 # $Id$
 
+if MANPAGES
 if SAIDAR
 man_MANS = saidar.1
 endif
 
 EXTRA_DIST = $(man_MANS)
 
-if BUILD_MANPAGES
 MAINTAINERCLEANFILES= $(man_MANS)
 
 .xml.1:

--- a/docs/statgrab/Makefile.am
+++ b/docs/statgrab/Makefile.am
@@ -2,6 +2,7 @@
 # http://www.i-scream.org/libstatgrab/
 # $Id$
 
+if MANPAGES
 if STATGRAB
 man_MANS = statgrab.1 statgrab-make-mrtg-config.1 \
 	   statgrab-make-mrtg-index.1
@@ -9,7 +10,6 @@ endif
 
 EXTRA_DIST = $(man_MANS)
 
-if BUILD_MANPAGES
 MAINTAINERCLEANFILES= $(man_MANS)
 
 .xml.1:


### PR DESCRIPTION
Previously, the --disable-man-build flag would stop the build from looking for the docbook2x tool and building the manual pages. However, it still tried to install the non-existent manual pages later, which failed.

This change renames that flag to --disable-man and makes it completely ignore the manual pages.